### PR TITLE
Removing PHPStan and adding PHPCPD

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: Comma separated list of file extensions to test.
     required: false
     default: php,module,inc,install,test,profile,theme,css,info,md,yml
+  suffix:
+    description: Comma separated list of file extensions to test used by phpcs.
+    required: false
+    default: .php,*.module,*.inc,*.install,*.test,*.profile,*.theme,*.js,*.css,*.info
 
 runs:
   using: "composite"
@@ -17,10 +21,10 @@ runs:
     - env:
         ACTION_PATH: ${{ inputs.path }}
         ACTION_EXTENSIONS: ${{ inputs.extensions }}
+        ACTION_SUFFIX: ${{ inputs.suffix }}
       run: ${{ github.action_path }}/lint.sh
       shell: bash
 
-      
 branding:
   icon: 'check-square'
   color: 'blue'

--- a/lint.sh
+++ b/lint.sh
@@ -6,7 +6,7 @@ set -e #Exit entire script if any command fails
 echo "Downloading dependencies ..."
 composer -q global require drupal/coder
 composer -q global require dealerdirect/phpcodesniffer-composer-installer
-curl -OLsS https://github.com/phpstan/phpstan/raw/master/phpstan.phar
+composer -q global require sebastian/phpcpd
 
 # Register sniffs
 echo "Registering sniffs ..."
@@ -18,6 +18,6 @@ echo "Running PHPCS for Drupal standards ..."
 
 echo "Running PHPCS for Drupal best practices ..."
 ~/.composer/vendor/bin/phpcs --standard=DrupalPractice --extensions=$ACTION_EXTENSIONS $ACTION_PATH
-  
-echo "Running PHPStan ..."
-php ./phpstan.phar analyse $ACTION_PATH
+
+echo "Running PHPCPD for copy/paste detection ..."
+~/.composer/vendor/bin/phpcpd --suffix=$ACTION_SUFFIX $ACTION_PATH


### PR DESCRIPTION
PHPStan module throws reflection errors because it can't find the base Drupal code to resolve referenced classes.

Adding PHPCPD to bring this CodeSniffer/Code Linting action up to parity with our own drush-test-no-empty code linting.