### PR TITLE
Removing sniff registry

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,8 @@ description: Runs static analysis on your PHP code.
 inputs:
   path:
     description: The path (or paths) to run the analysis on.
-    required: true
+    required: false
+    default: ./
   extensions:
     description: Comma separated list of file extensions to test.
     required: false

--- a/lint.sh
+++ b/lint.sh
@@ -2,9 +2,6 @@
 
 set -e #Exit entire script if any command fails
 
-echo "Outputing env variables ..."
-env
-
 # Download dependencies
 echo "Downloading dependencies ..."
 composer -q global require drupal/coder

--- a/lint.sh
+++ b/lint.sh
@@ -8,10 +8,6 @@ composer -q global require drupal/coder
 composer -q global require dealerdirect/phpcodesniffer-composer-installer
 composer -q global require sebastian/phpcpd
 
-# Register sniffs
-echo "Registering sniffs ..."
-~/.composer/vendor/bin/phpcs -q --config-set installed_paths ~/.composer/vendor/drupal/coder/coder_sniffer/
-
 # Run linting and static analysis
 echo "Running PHPCS for Drupal standards ..."
 ~/.composer/vendor/bin/phpcs -s --standard=Drupal,DrupalPractice --extensions=$ACTION_EXTENSIONS $ACTION_PATH --ignore=*.md

--- a/lint.sh
+++ b/lint.sh
@@ -2,6 +2,9 @@
 
 set -e #Exit entire script if any command fails
 
+echo "Outputing env variables ..."
+env
+
 # Download dependencies
 echo "Downloading dependencies ..."
 composer -q global require drupal/coder


### PR DESCRIPTION
As of [drupal/coder:8.3.14](https://git.drupalcode.org/project/coder/-/commit/adb06efa79ba8b91afed2f351014a6b94192622f) they changed the install path for the sniff configs, they also made sniff registry automatic. Removing that part of our code sniffer process as it was throwing issues with the new version of the drupal/coder.