### PR TITLE
Add test workfow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,9 +15,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: .github/actions/CodeSniffer
-      - name: checks for files
-        run: |
-          ls
-          ls -R .github
+
       - name: Run CodeSniffer
         uses: ./.github/actions/CodeSniffer

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,4 +20,4 @@ jobs:
           ls
           ls -R .github
       - name: Run CodeSniffer
-        uses: .github/actions/CodeSniffer
+        uses: ./.github/actions/CodeSniffer

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,20 @@
+name: Test
+on:
+  push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+        with:
+          path: .github/actions/CodeSniffer
+
+      - name: Checkout Test Drupal module
+        uses: actions/checkout@v2
+        with:
+          repository: discoverygarden/embargoes
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run CodeSniffer
+        uses: ./.github/actions/CodeSniffer

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,16 +5,19 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v2
-        with:
-          path: .github/actions/CodeSniffer
-
       - name: Checkout Test Drupal module
         uses: actions/checkout@v2
         with:
           repository: discoverygarden/embargoes
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+        with:
+          path: .github/actions/CodeSniffer
+      - name: checks for files
+        run: |
+          ls
+          ls -R .github
       - name: Run CodeSniffer
-        uses: ./.github/actions/CodeSniffer
+        uses: .github/actions/CodeSniffer


### PR DESCRIPTION
Adds a workflow to test the github action.

Clones a php module then the action to simulate being called from another repository. Currently it is cloning discoverygarden/embargoes but ideally would have a sample module with different failure conditions.
