### PR TITLE
Allows 'lint.sh' to be run on different platforms / shellcheck compli…

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -2,6 +2,15 @@
 
 set -e #Exit entire script if any command fails
 
+COMPOSER_HOME=$(composer -n config --global home)
+COMPOSER_BIN="${COMPOSER_HOME}/vendor/bin"
+readonly COMPOSER_HOME COMPOSER_BIN
+
+ACTION_PATH="${ACTION_PATH:-./}"
+ACTION_EXTENSIONS="${ACTION_EXTENSIONS:-php,module,inc,install,test,profile,theme,css,info,md,yml}"
+ACTION_SUFFIX="${ACTION_SUFFIX:-.php,*.module,*.inc,*.install,*.test,*.profile,*.theme,*.js,*.css,*.info}"
+ACTION_LINT="${ACTION_LINT:-php,module,inc,install,test}"
+
 # Download dependencies
 echo "Downloading dependencies ..."
 composer -q global require drupal/coder
@@ -10,10 +19,10 @@ composer -q global require sebastian/phpcpd
 
 # Run linting and static analysis
 echo "Running PHPCS for Drupal standards ..."
-~/.composer/vendor/bin/phpcs -s --standard=Drupal,DrupalPractice --extensions=$ACTION_EXTENSIONS $ACTION_PATH --ignore=*.md
+"${COMPOSER_BIN}/phpcs" -s --standard=Drupal,DrupalPractice --extensions="${ACTION_EXTENSIONS}" "${ACTION_PATH}" --ignore="*.md" .
 
 echo "Running PHPCS Generic sniffs ..."
-~/.composer/vendor/bin/phpcs --standard=Generic --sniffs=Generic.PHP.Syntax --extensions=$ACTION_LINT $ACTION_PATH
+"${COMPOSER_BIN}/phpcs" --standard=Generic --sniffs=Generic.PHP.Syntax --extensions="${ACTION_LINT}" "${ACTION_PATH}"
 
 echo "Running PHPCPD for copy/paste detection ..."
-~/.composer/vendor/bin/phpcpd --suffix=$ACTION_SUFFIX $ACTION_PATH
+"${COMPOSER_BIN}/phpcpd" --suffix="${ACTION_SUFFIX}" "${ACTION_PATH}"


### PR DESCRIPTION
…ance.

@nchiasson-dgi mind having a quick look over this, these changes allow me to use it locally (composer doesn't always install in the users `~/.composer` home directory on some systems with xdg installed it goes into `~/.config/composer`. Also defaults are provided to make it callable outside of the context of Github actions. 